### PR TITLE
Dev 250soc plus (#78)

### DIFF
--- a/actions/hls_memcopy_1024/sw/snap_memcopy.c
+++ b/actions/hls_memcopy_1024/sw/snap_memcopy.c
@@ -77,7 +77,7 @@ static void usage(const char *prog)
 	       "\n"
 	       "Example on a real card :\n"
 	       "------------------------\n"
-	       "cd /home/snap && export ACTION_ROOT=/home/snap/actions/hls_memcopy\n"
+	       "cd /home/oc-accel && export ACTION_ROOT=/home/oc-accel/actions/hls_memcopy_1024\n"
 	       "source snap_path.sh\n"
 	       "oc_maint -vv\n"
 	       "echo create a 512MB file with random data ...wait...\n"

--- a/actions/hls_memcopy_1024/tests/hw_test.sh
+++ b/actions/hls_memcopy_1024/tests/hw_test.sh
@@ -51,6 +51,7 @@ while getopts ":C:t:d:Nh" opt; do
     ;;
     d)
     duration=$OPTARG;
+    echo "test duration :    $duration"
     ;;
     N)
     noirq=" -N ";

--- a/defconfig/OC-BW250SOC.hdl_example.defconfig
+++ b/defconfig/OC-BW250SOC.hdl_example.defconfig
@@ -1,0 +1,80 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+BW250SOC=y
+# AD9H3 is not set
+# AD9H7 is not set
+FPGACARD="BW250SOC"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="64"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xczu19eg-ffvd1760-2-i"
+NUM_OF_ACTIONS=1
+# HDL_ACTION is not set
+HDL_EXAMPLE=y
+# HDL_SINGLE_ENGINE is not set
+# HLS_ACTION is not set
+# HLS_HELLOWORLD_512 is not set
+# HLS_HELLOWORLD_1024 is not set
+# HLS_MEMCOPY_1024 is not set
+ACTION_HALF_WIDTH=y
+HALF_WIDTH="TRUE"
+# ENABLE_HLS_SUPPORT is not set
+HLS_SUPPORT="FALSE"
+# DISABLE_SDRAM_AND_BRAM is not set
+# FORCE_SDRAM_OR_BRAM is not set
+# ENABLE_DDR is not set
+SDRAM_USED="FALSE"
+HBM_USED="FALSE"
+# ENABLE_BRAM is not set
+BRAM_USED="FALSE"
+DDR3_USED="FALSE"
+DDR4_USED="FALSE"
+DDRI_USED="FALSE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=1
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+ODMA_USED="FALSE"
+ODMA_ST_MODE_USED="FALSE"
+ODMA_512_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/defconfig/OC-BW250SOC.hdl_single_engine.defconfig
+++ b/defconfig/OC-BW250SOC.hdl_single_engine.defconfig
@@ -1,0 +1,77 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+BW250SOC=y
+# AD9H3 is not set
+# AD9H7 is not set
+FPGACARD="BW250SOC"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="64"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xczu19eg-ffvd1760-2-i"
+NUM_OF_ACTIONS=1
+# HDL_ACTION is not set
+# HDL_EXAMPLE is not set
+HDL_SINGLE_ENGINE=y
+# HLS_ACTION is not set
+# HLS_HELLOWORLD_512 is not set
+# HLS_HELLOWORLD_1024 is not set
+# HLS_MEMCOPY_1024 is not set
+HALF_WIDTH="FALSE"
+# ENABLE_HLS_SUPPORT is not set
+HLS_SUPPORT="FALSE"
+DISABLE_SDRAM_AND_BRAM=y
+# FORCE_SDRAM_OR_BRAM is not set
+SDRAM_USED="FALSE"
+HBM_USED="FALSE"
+BRAM_USED="FALSE"
+DDR3_USED="FALSE"
+DDR4_USED="FALSE"
+DDRI_USED="FALSE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=1
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+ODMA_USED="FALSE"
+ODMA_ST_MODE_USED="FALSE"
+ODMA_512_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/defconfig/OC-BW250SOC.hls_helloworld_1024.defconfig
+++ b/defconfig/OC-BW250SOC.hls_helloworld_1024.defconfig
@@ -1,0 +1,77 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+BW250SOC=y
+# AD9H3 is not set
+# AD9H7 is not set
+FPGACARD="BW250SOC"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="64"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xczu19eg-ffvd1760-2-i"
+NUM_OF_ACTIONS=1
+# HDL_ACTION is not set
+# HDL_EXAMPLE is not set
+# HDL_SINGLE_ENGINE is not set
+# HLS_ACTION is not set
+# HLS_HELLOWORLD_512 is not set
+HLS_HELLOWORLD_1024=y
+# HLS_MEMCOPY_1024 is not set
+HALF_WIDTH="FALSE"
+ENABLE_HLS_SUPPORT=y
+HLS_SUPPORT="TRUE"
+DISABLE_SDRAM_AND_BRAM=y
+# FORCE_SDRAM_OR_BRAM is not set
+SDRAM_USED="FALSE"
+HBM_USED="FALSE"
+BRAM_USED="FALSE"
+DDR3_USED="FALSE"
+DDR4_USED="FALSE"
+DDRI_USED="FALSE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=1
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+ODMA_USED="FALSE"
+ODMA_ST_MODE_USED="FALSE"
+ODMA_512_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/defconfig/OC-BW250SOC.hls_helloworld_512.defconfig
+++ b/defconfig/OC-BW250SOC.hls_helloworld_512.defconfig
@@ -1,0 +1,78 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+BW250SOC=y
+# AD9H3 is not set
+# AD9H7 is not set
+FPGACARD="BW250SOC"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="64"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xczu19eg-ffvd1760-2-i"
+NUM_OF_ACTIONS=1
+# HDL_ACTION is not set
+# HDL_EXAMPLE is not set
+# HDL_SINGLE_ENGINE is not set
+# HLS_ACTION is not set
+HLS_HELLOWORLD_512=y
+# HLS_HELLOWORLD_1024 is not set
+# HLS_MEMCOPY_1024 is not set
+ACTION_HALF_WIDTH=y
+HALF_WIDTH="TRUE"
+ENABLE_HLS_SUPPORT=y
+HLS_SUPPORT="TRUE"
+DISABLE_SDRAM_AND_BRAM=y
+# FORCE_SDRAM_OR_BRAM is not set
+SDRAM_USED="FALSE"
+HBM_USED="FALSE"
+BRAM_USED="FALSE"
+DDR3_USED="FALSE"
+DDR4_USED="FALSE"
+DDRI_USED="FALSE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=1
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+ODMA_USED="FALSE"
+ODMA_ST_MODE_USED="FALSE"
+ODMA_512_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/defconfig/OC-BW250SOC.hls_memcopy_1024.defconfig
+++ b/defconfig/OC-BW250SOC.hls_memcopy_1024.defconfig
@@ -1,0 +1,82 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Kernel Configuration
+#
+# AD9V3 is not set
+BW250SOC=y
+# AD9H3 is not set
+# AD9H7 is not set
+FPGACARD="BW250SOC"
+FLASH_INTERFACE="SPIx8"
+FLASH_SIZE="64"
+FLASH_FACTORYADDR="0x00000000"
+FLASH_USERADDR="0x08000000"
+OPENCAPI30=y
+CAPI_VER="opencapi30"
+FPGACHIP="xczu19eg-ffvd1760-2-i"
+NUM_OF_ACTIONS=1
+# HDL_ACTION is not set
+# HDL_EXAMPLE is not set
+# HDL_SINGLE_ENGINE is not set
+# HLS_ACTION is not set
+# HLS_HELLOWORLD_512 is not set
+# HLS_HELLOWORLD_1024 is not set
+HLS_MEMCOPY_1024=y
+HALF_WIDTH="FALSE"
+ENABLE_HLS_SUPPORT=y
+HLS_SUPPORT="TRUE"
+# DISABLE_SDRAM_AND_BRAM is not set
+FORCE_SDRAM_OR_BRAM=y
+FORCE_SDRAM=y
+ENABLE_DDR=y
+SDRAM_USED="TRUE"
+HBM_USED="FALSE"
+# ENABLE_BRAM is not set
+BRAM_USED="FALSE"
+DDR3_USED="FALSE"
+ENABLE_DDR4=y
+DDR4_USED="TRUE"
+ENABLE_DDRI=y
+DDRI_USED="TRUE"
+DISABLE_NVME=y
+# FORCE_NVME is not set
+NVME_USED="FALSE"
+USER_CLOCK="FALSE"
+# ACTION_USER_CLOCK is not set
+SIM_XSIM=y
+# SIM_IRUN is not set
+# SIM_XCELIUM is not set
+# SIM_MODELSIM is not set
+# SIM_QUESTA is not set
+# NO_SIM is not set
+SIMULATOR="xsim"
+DENALI_USED="FALSE"
+OCSE_PATH="../ocse"
+
+#
+# ================= Advanced Options: =================
+#
+SPEED_25G=y
+# SPEED_20G is not set
+PHY_SPEED="25.78125"
+AXI_ID_WIDTH=1
+# Action_clock_50MHz is not set
+# Action_clock_100MHz is not set
+# Action_clock_150MHz is not set
+Action_clock_200MHz=y
+# Action_clock_250MHz is not set
+# Action_clock_300MHz is not set
+# Action_clock_350MHz is not set
+# Action_clock_400MHz is not set
+USER_CLOCK_FREQ=200
+HLS_CLOCK_PERIOD_CONSTRAINT="4ns"
+# ENABLE_ILA is not set
+ILA_DEBUG="FALSE"
+CLOUD_USER_FLOW="FALSE"
+CLOUD_BUILD_BITFILE="FALSE"
+UNIT_SIM_USED="FALSE"
+ODMA_USED="FALSE"
+ODMA_ST_MODE_USED="FALSE"
+ODMA_512_USED="FALSE"
+ENABLE_FLASH=y
+FLASH_USED="TRUE"

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -136,6 +136,11 @@ check_snap_settings:
 	@echo "                        PHY_SPEED       = $(PHY_SPEED)"
 	@echo "                        NUM_OF_ACTIONS  = $(NUM_OF_ACTIONS)"
 	@echo "                        HLS_SUPPORT     = $(HLS_SUPPORT)"
+	@if [ "$(HALF_WIDTH)" == "TRUE" ]; then \
+		echo "                        ACTION HOST I/F = 512 bits";\
+	else \
+		echo "                        ACTION HOST I/F = 1024 bits";\
+	fi
 	@echo "                        BRAM_USED       = $(BRAM_USED)"
 	@echo "                        SDRAM_USED      = $(SDRAM_USED)"
 	@echo "                        HBM_USED        = $(HBM_USED)"

--- a/hardware/hdl/core/framework_afu.v
+++ b/hardware/hdl/core/framework_afu.v
@@ -215,6 +215,28 @@ module framework_afu (
     , output  [0 : 0]        c0_ddr4_ck_c
     , output  [0 : 0]        c0_ddr4_ck_t
    `endif
+  `ifdef BW250SOC
+  
+   // DDR4 SDRAM Interface
+ // , output [511:0]       dbg_bus //Unused
+    , input                  c0_sys_clk_p
+    , input                  c0_sys_clk_n
+    , output  [16 : 0]       c0_ddr4_adr
+    , output  [1 : 0]        c0_ddr4_ba
+    , output  [0 : 0]        c0_ddr4_cke
+    , output  [0 : 0]        c0_ddr4_cs_n
+    , inout   [8 : 0]        c0_ddr4_dm_dbi_n
+    , inout   [71 : 0]       c0_ddr4_dq
+    , inout   [8 : 0]        c0_ddr4_dqs_c
+    , inout   [8 : 0]        c0_ddr4_dqs_t
+    , output  [0 : 0]        c0_ddr4_odt
+    , output  [0 : 0]        c0_ddr4_bg
+    , output                 c0_ddr4_reset_n
+    , output                 c0_ddr4_act_n
+    , output  [0 : 0]        c0_ddr4_ck_c
+    , output  [0 : 0]        c0_ddr4_ck_t
+   `endif
+
    `endif
   );
 
@@ -677,6 +699,12 @@ module framework_afu (
   wire [511 : 0]  ddr4_dbg_bus                   ;
   wire            memctl0_ui_clk_sync_rst        ; //reset generated from DDR MIG
 `endif
+`ifdef BW250SOC
+  wire            ddr4_dbg_clk                   ;
+  wire [511 : 0]  ddr4_dbg_bus                   ;
+  wire            memctl0_ui_clk_sync_rst        ; //reset generated from DDR MIG
+`endif
+
 `endif
 
 
@@ -1992,6 +2020,91 @@ block_RAM block_ram_i1
 
 `ifdef ENABLE_DDR
 `ifdef AD9V3
+  //
+  // DDR4SDRAM
+  //
+     ddr4sdram ddr4memctl0_bank
+      (
+      .c0_init_calib_complete      ( memctl0_init_calib_complete ) ,
+      .dbg_clk                     ( ddr4_dbg_clk                ) ,
+      .c0_sys_clk_p                ( c0_sys_clk_p                ) ,
+      .c0_sys_clk_n                ( c0_sys_clk_n                ) ,
+      .dbg_bus                     ( ddr4_dbg_bus                ) ,
+      .c0_ddr4_adr                 ( c0_ddr4_adr                 ) ,
+      .c0_ddr4_ba                  ( c0_ddr4_ba                  ) ,
+      .c0_ddr4_cke                 ( c0_ddr4_cke                 ) ,
+      .c0_ddr4_cs_n                ( c0_ddr4_cs_n                ) ,
+      .c0_ddr4_dm_dbi_n            ( c0_ddr4_dm_dbi_n            ) ,
+      .c0_ddr4_dq                  ( c0_ddr4_dq                  ) ,
+      .c0_ddr4_dqs_c               ( c0_ddr4_dqs_c               ) ,
+      .c0_ddr4_dqs_t               ( c0_ddr4_dqs_t               ) ,
+      .c0_ddr4_odt                 ( c0_ddr4_odt                 ) ,
+      .c0_ddr4_bg                  ( c0_ddr4_bg                  ) ,
+      .c0_ddr4_reset_n             ( c0_ddr4_reset_n             ) ,
+      .c0_ddr4_act_n               ( c0_ddr4_act_n               ) ,
+      .c0_ddr4_ck_c                ( c0_ddr4_ck_c                ) ,
+      .c0_ddr4_ck_t                ( c0_ddr4_ck_t                ) ,
+      .c0_ddr4_ui_clk              ( memctl0_ui_clk              ) ,//output
+      .c0_ddr4_ui_clk_sync_rst     ( memctl0_ui_clk_sync_rst     ) ,//output
+      .c0_ddr4_aresetn             ( memctl0_axi_rst_n           ) ,
+      .c0_ddr4_s_axi_ctrl_awvalid  ( memctl0_axi_ctrl_awvalid    ) ,
+      .c0_ddr4_s_axi_ctrl_awready  ( memctl0_axi_ctrl_awready    ) ,
+      .c0_ddr4_s_axi_ctrl_awaddr   ( memctl0_axi_ctrl_awaddr     ) ,
+      .c0_ddr4_s_axi_ctrl_wvalid   ( memctl0_axi_ctrl_wvalid     ) ,
+      .c0_ddr4_s_axi_ctrl_wready   ( memctl0_axi_ctrl_wready     ) ,
+      .c0_ddr4_s_axi_ctrl_wdata    ( memctl0_axi_ctrl_wdata      ) ,
+      .c0_ddr4_s_axi_ctrl_bvalid   ( memctl0_axi_ctrl_bvalid     ) ,
+      .c0_ddr4_s_axi_ctrl_bready   ( memctl0_axi_ctrl_bready     ) ,
+      .c0_ddr4_s_axi_ctrl_bresp    ( memctl0_axi_ctrl_bresp      ) ,
+      .c0_ddr4_s_axi_ctrl_arvalid  ( memctl0_axi_ctrl_arvalid    ) ,
+      .c0_ddr4_s_axi_ctrl_arready  ( memctl0_axi_ctrl_arready    ) ,
+      .c0_ddr4_s_axi_ctrl_araddr   ( memctl0_axi_ctrl_araddr     ) ,
+      .c0_ddr4_s_axi_ctrl_rvalid   ( memctl0_axi_ctrl_rvalid     ) ,
+      .c0_ddr4_s_axi_ctrl_rready   ( memctl0_axi_ctrl_rready     ) ,
+      .c0_ddr4_s_axi_ctrl_rdata    ( memctl0_axi_ctrl_rdata      ) ,
+      .c0_ddr4_s_axi_ctrl_rresp    ( memctl0_axi_ctrl_rresp      ) ,
+      .c0_ddr4_interrupt           ( memctl0_interrupt           ) ,
+      .c0_ddr4_s_axi_awid          ( memctl0_axi_awid            ) ,
+      .c0_ddr4_s_axi_awaddr        ( memctl0_axi_awaddr          ) ,
+      .c0_ddr4_s_axi_awlen         ( memctl0_axi_awlen           ) ,
+      .c0_ddr4_s_axi_awsize        ( memctl0_axi_awsize          ) ,
+      .c0_ddr4_s_axi_awburst       ( memctl0_axi_awburst         ) ,
+      .c0_ddr4_s_axi_awlock        ( memctl0_axi_awlock          ) ,
+      .c0_ddr4_s_axi_awcache       ( memctl0_axi_awcache         ) ,
+      .c0_ddr4_s_axi_awprot        ( memctl0_axi_awprot          ) ,
+      .c0_ddr4_s_axi_awqos         ( memctl0_axi_awqos           ) ,
+      .c0_ddr4_s_axi_awvalid       ( memctl0_axi_awvalid         ) ,
+      .c0_ddr4_s_axi_awready       ( memctl0_axi_awready         ) ,
+      .c0_ddr4_s_axi_wdata         ( memctl0_axi_wdata           ) ,
+      .c0_ddr4_s_axi_wstrb         ( memctl0_axi_wstrb           ) ,
+      .c0_ddr4_s_axi_wlast         ( memctl0_axi_wlast           ) ,
+      .c0_ddr4_s_axi_wvalid        ( memctl0_axi_wvalid          ) ,
+      .c0_ddr4_s_axi_wready        ( memctl0_axi_wready          ) ,
+      .c0_ddr4_s_axi_bready        ( memctl0_axi_bready          ) ,
+      .c0_ddr4_s_axi_bid           ( memctl0_axi_bid             ) ,
+      .c0_ddr4_s_axi_bresp         ( memctl0_axi_bresp           ) ,
+      .c0_ddr4_s_axi_bvalid        ( memctl0_axi_bvalid          ) ,
+      .c0_ddr4_s_axi_arid          ( memctl0_axi_arid            ) ,
+      .c0_ddr4_s_axi_araddr        ( memctl0_axi_araddr          ) ,
+      .c0_ddr4_s_axi_arlen         ( memctl0_axi_arlen           ) ,
+      .c0_ddr4_s_axi_arsize        ( memctl0_axi_arsize          ) ,
+      .c0_ddr4_s_axi_arburst       ( memctl0_axi_arburst         ) ,
+      .c0_ddr4_s_axi_arlock        ( memctl0_axi_arlock          ) ,
+      .c0_ddr4_s_axi_arcache       ( memctl0_axi_arcache         ) ,
+      .c0_ddr4_s_axi_arprot        ( memctl0_axi_arprot          ) ,
+      .c0_ddr4_s_axi_arqos         ( memctl0_axi_arqos           ) ,
+      .c0_ddr4_s_axi_arvalid       ( memctl0_axi_arvalid         ) ,
+      .c0_ddr4_s_axi_arready       ( memctl0_axi_arready         ) ,
+      .c0_ddr4_s_axi_rready        ( memctl0_axi_rready          ) ,
+      .c0_ddr4_s_axi_rlast         ( memctl0_axi_rlast           ) ,
+      .c0_ddr4_s_axi_rvalid        ( memctl0_axi_rvalid          ) ,
+      .c0_ddr4_s_axi_rresp         ( memctl0_axi_rresp           ) ,
+      .c0_ddr4_s_axi_rid           ( memctl0_axi_rid             ) ,
+      .c0_ddr4_s_axi_rdata         ( memctl0_axi_rdata           ) ,
+      .sys_rst                     ( memctl0_reset_q             )
+    );
+`endif
+`ifdef BW250SOC
   //
   // DDR4SDRAM
   //

--- a/hardware/hdl/core/oc_function.v
+++ b/hardware/hdl/core/oc_function.v
@@ -217,6 +217,26 @@ module oc_function (
     , output  [0 : 0]        c0_ddr4_ck_c
     , output  [0 : 0]        c0_ddr4_ck_t
    `endif
+   `ifdef BW250SOC
+   // DDR4 SDRAM Interface
+ // , output [511:0]       dbg_bus //Unused
+    , input                  c0_sys_clk_p
+    , input                  c0_sys_clk_n
+    , output  [16 : 0]       c0_ddr4_adr
+    , output  [1 : 0]        c0_ddr4_ba
+    , output  [0 : 0]        c0_ddr4_cke
+    , output  [0 : 0]        c0_ddr4_cs_n
+    , inout   [8 : 0]        c0_ddr4_dm_dbi_n
+    , inout   [71 : 0]       c0_ddr4_dq
+    , inout   [8 : 0]        c0_ddr4_dqs_c
+    , inout   [8 : 0]        c0_ddr4_dqs_t
+    , output  [0 : 0]        c0_ddr4_odt
+    , output  [0 : 0]        c0_ddr4_bg
+    , output                 c0_ddr4_reset_n
+    , output                 c0_ddr4_act_n
+    , output  [0 : 0]        c0_ddr4_ck_c
+    , output  [0 : 0]        c0_ddr4_ck_t
+   `endif
    `endif
 
 `ifdef ENABLE_HBM
@@ -467,6 +487,27 @@ framework_afu  fw_afu
       .c0_ddr4_ck_c     ( c0_ddr4_ck_c     ) ,
       .c0_ddr4_ck_t     ( c0_ddr4_ck_t     ) ,
    `endif
+   `ifdef BW250SOC
+  
+   // DDR4 SDRAM Interface
+      .c0_sys_clk_p     ( c0_sys_clk_p     ) ,
+      .c0_sys_clk_n     ( c0_sys_clk_n     ) ,
+      .c0_ddr4_adr      ( c0_ddr4_adr      ) ,
+      .c0_ddr4_ba       ( c0_ddr4_ba       ) ,
+      .c0_ddr4_cke      ( c0_ddr4_cke      ) ,
+      .c0_ddr4_cs_n     ( c0_ddr4_cs_n     ) ,
+      .c0_ddr4_dm_dbi_n ( c0_ddr4_dm_dbi_n ) ,
+      .c0_ddr4_dq       ( c0_ddr4_dq       ) ,
+      .c0_ddr4_dqs_c    ( c0_ddr4_dqs_c    ) ,
+      .c0_ddr4_dqs_t    ( c0_ddr4_dqs_t    ) ,
+      .c0_ddr4_odt      ( c0_ddr4_odt      ) ,
+      .c0_ddr4_bg       ( c0_ddr4_bg       ) ,
+      .c0_ddr4_reset_n  ( c0_ddr4_reset_n  ) ,
+      .c0_ddr4_act_n    ( c0_ddr4_act_n    ) ,
+      .c0_ddr4_ck_c     ( c0_ddr4_ck_c     ) ,
+      .c0_ddr4_ck_t     ( c0_ddr4_ck_t     ) ,
+   `endif
+
    `endif
 
       // -- AFU Index

--- a/hardware/hdl/core/snap_global_vars.v_source
+++ b/hardware/hdl/core/snap_global_vars.v_source
@@ -23,6 +23,10 @@
 `define AD9V3
 #endif
 
+#if defined(CONFIG_BW250SOC)
+`define BW250SOC
+#endif
+
 #if defined(CONFIG_AD9H3)
 `define AD9H3
 #endif

--- a/hardware/setup/create_framework.tcl
+++ b/hardware/setup/create_framework.tcl
@@ -186,7 +186,6 @@ if { $simulator != "nosim" } {
   puts "                        importing simulation files for $simulator"
   if {$unit_sim_used == "TRUE"} {
     add_files -scan_for_includes $root_dir/sim/unit_verif  >> $log_file
-
   }
   add_files    -fileset sim_1 -norecurse -scan_for_includes $sim_src/$sim_top.sv  >> $log_file
   set_property file_type SystemVerilog [get_files $sim_src/$sim_top.sv]
@@ -197,6 +196,11 @@ if { $simulator != "nosim" } {
     add_files    -fileset sim_1 -norecurse -scan_for_includes $ip_dir/ddr4sdram_ex/imports/ddr4_model.sv  >> $log_file
     add_files    -fileset sim_1 -norecurse -scan_for_includes $sim_dir/src/ddr4_dimm_ad9v3.sv  >> $log_file
     set_property used_in_synthesis false           [get_files $sim_dir/src/ddr4_dimm_ad9v3.sv]
+  }
+  if { ($fpga_card == "BW250SOC") && ($sdram_used == "TRUE") } {
+    add_files    -fileset sim_1 -norecurse -scan_for_includes $ip_dir/ddr4sdram_ex/imports/ddr4_model.sv  >> $log_file
+    add_files    -fileset sim_1 -norecurse -scan_for_includes $sim_dir/src/ddr4_dimm_250soc.sv  >> $log_file
+    set_property used_in_synthesis false           [get_files $sim_dir/src/ddr4_dimm_250soc.sv]
   }
 }
 
@@ -224,7 +228,6 @@ foreach ip_xci [glob -nocomplain -dir $action_ip_dir */*.xci] {
   export_ip_user_files -of_objects  [get_files "$ip_xci"] -no_script -sync -force >> $log_file
 }
 
-
 # Add OpenCAPI board support package
 
 if { $unit_sim_used == "TRUE" } {
@@ -244,6 +247,20 @@ if { $unit_sim_used == "TRUE" } {
     }
 }
 
+if {$fpga_card == "BW250SOC"} {
+  puts "                        adding Flash IP "
+  add_files $ip_dir/flash_ip_project/flash_ip_project.srcs/sources_1/bd/design_1/hdl/design_1_wrapper.vhd -norecurse  >> $log_file
+  add_files -norecurse $ip_dir/flash_ip_project/flash_ip_project.srcs/sources_1/bd/design_1/design_1.bd  >> $log_file
+  export_ip_user_files -of_objects  [get_files  $ip_dir/flash_ip_project/flash_ip_project.srcs/sources_1/bd/design_1/design_1.bd] -lib_map_path [list {{ies=$root_dir/viv_project/framework.cache/compile_simlib/ies}}] -no_script -sync -force -quiet
+#  puts "                        adding  $fpga_card_dir/ip/qspi_mb.elf"
+#  add_files -norecurse [get_files "$fpga_card_dir/ip/qspi_mb.elf"]
+#  puts "                        setting prop1"
+#  set_property SCOPED_TO_REF design_1 [get_files -all -of_objects [get_fileset sources_1] {$fpga_card_dir/ip/qspi_mb.elf}]
+#  puts "                        setting prop2"
+#  set_property SCOPED_TO_CELLS { microblaze_0 } [get_files -all -of_objects [get_fileset sources_1] {$fpga_card_dir/ip/qspi_mb.elf}]
+}
+
+
 # XDC
 puts "                        importing other XDCs"
 
@@ -257,7 +274,7 @@ if { $user_clock == "TRUE" } {
 }
 
 # DDR XDCs
-if { $fpga_card == "AD9V3" } {
+if { ($fpga_card == "AD9V3") || ($fpga_card == "BW250SOC") } {
   if { $sdram_used == "TRUE" } {
     add_files -fileset constrs_1 -norecurse $top_xdc_dir/snap_ddr4_b0pins.xdc 
     set_property used_in_synthesis false [get_files $top_xdc_dir/snap_ddr4_b0pins.xdc]

--- a/hardware/setup/patch_version.sh
+++ b/hardware/setup/patch_version.sh
@@ -38,6 +38,8 @@ elif [ "$FPGACARD" == "AD9H3" ]; then
   CARD_TYPE="32"
 elif [ "$FPGACARD" == "AD9H7" ]; then
   CARD_TYPE="33"
+elif [ "$FPGACARD" == "BW250SOC" ]; then
+  CARD_TYPE="34"
 fi
 
 SRC="define CARD_TYPE 8'h.*"

--- a/hardware/setup/snap_impl_step.tcl
+++ b/hardware/setup/snap_impl_step.tcl
@@ -54,6 +54,18 @@ if { $impl_flow == "CLOUD_BASE" } {
   set opt_route_directive [get_property STEPS.POST_ROUTE_PHYS_OPT_DESIGN.ARGS.DIRECTIVE [get_runs impl_1]]
 }
 
+## Adding elf file to project and loading on microblaze BRAM for 250SOC only
+
+if { $fpgacard == "BW250SOC" } {
+puts [format "%-*s%-*s%-*s%-*s"  $widthCol1 "" $widthCol2 "" $widthCol3 "Adding elf file" $widthCol4 "[clock format [clock seconds] -format {%T %a %b %d %Y}]"]
+import_files -fileset sim_1 -norecurse $root_dir/oc-bip/board_support_packages/bw250soc/ip/qspi_mb_golden.elf -force
+import_files -norecurse $root_dir/oc-bip/board_support_packages/bw250soc/ip/qspi_mb_golden.elf -force
+set_property SCOPED_TO_REF design_1 [get_files -all -of_objects [get_fileset sources_1] [get_files $root_dir/viv_project/framework.srcs/sources_1/imports/ip/qspi_mb_golden.elf]]
+set_property SCOPED_TO_CELLS { microblaze_0 } [get_files -all -of_objects [get_fileset sources_1] [get_files $root_dir/viv_project/framework.srcs/sources_1/imports/ip/qspi_mb_golden.elf]]
+set_property SCOPED_TO_REF design_1 [get_files -all -of_objects [get_fileset sim_1] [get_files $root_dir/viv_project/framework.srcs/sim_1/imports/ip/qspi_mb_golden.elf]]
+set_property SCOPED_TO_CELLS { microblaze_0 } [get_files -all -of_objects [get_fileset sim_1] [get_files $root_dir/viv_project/framework.srcs/sim_1/imports/ip/qspi_mb_golden.elf]]
+}
+
 ##
 ## optimizing design
 if { $cloud_flow == "TRUE" } {
@@ -79,6 +91,7 @@ if { [catch "$command > $logfile" errMsg] } {
   write_checkpoint   -force $dcp_dir/${step}.dcp          >> $logfile
   report_utilization -file  ${rpt_dir}_${step}_utilization.rpt -quiet
 }
+
 
 ##
 ## Vivado 2017.4 has problems to place the SNAP core logic, if they can place inside the PSL

--- a/scripts/Kconfig
+++ b/scripts/Kconfig
@@ -19,7 +19,7 @@ choice
 		select DISABLE_NVME
 		help
 		  AlphaData 9V3 has ethernet and 16GB DDR4 SDRAM. Uses Xilinx FPGA VU3P.
-	
+
 	config AD9H3
 		bool "OpenCAPI3.0: AlphaData 9H3 (VU33P with HBM)"
 		select OPENCAPI30
@@ -33,24 +33,34 @@ choice
 		select DISABLE_NVME
 		help
 		  AlphaData 9H7 has ethernet and 2x 4GB HBM Gen2. Uses Xilinx FPGA VU37P.
+
+	config BW250SOC
+		bool "OpenCAPI3.0: Bittware 250SOC (ZU19EG with DDR)"
+		select OPENCAPI30
+		select DISABLE_NVME
+		select ENABLE_FLASH
+		help
+		  Bittware 250SOC has ethernet and 8GB DDR4 SDRAM each on PL and PS side. Uses Xilinx ZynqMP SOC ZU19EG.
+	
 endchoice
 
 
 config FPGACARD
 	string
 	default "AD9V3"  if AD9V3
+	default "BW250SOC"  if BW250SOC
 	default "AD9H3"  if AD9H3
 	default "AD9H7"  if AD9H7
 
 config FLASH_INTERFACE
 	string
-	default "SPIx8"  if  AD9V3 || AD9H3 || AD9H7
+	default "SPIx8"  if  AD9V3 || AD9H3 || AD9H7 || BW250SOC
 
 #FLASH_SIZE: in MB
 config FLASH_SIZE
 	string
 	default 128 if AD9H7
-	default 64 if AD9V3 || AD9H3
+	default 64 if AD9V3 || AD9H3 || BW250SOC
 
 #FLASH_FACTORYADDR: For all cards, factory address is 0x0
 config FLASH_FACTORYADDR
@@ -60,7 +70,7 @@ config FLASH_FACTORYADDR
 #FLASH_USERADDR: For SPI, it is byte address.
 config FLASH_USERADDR
 	string
-	default 0x08000000 if AD9V3 || AD9H3 || AD9H7
+	default 0x08000000 if AD9V3 || AD9H3 || AD9H7 || BW250SOC
 
 config OPENCAPI30
 	bool
@@ -73,6 +83,7 @@ config CAPI_VER
 config FPGACHIP
 	string
 	default "xcvu3p-ffvc1517-2-e" if AD9V3
+	default "xczu19eg-ffvd1760-2-i" if BW250SOC
 	default "xcvu33p-fsvh2104-2-e" if AD9H3
 	default "xcvu37p-fsvh2892-2-e" if AD9H7
 
@@ -237,13 +248,13 @@ config FORCE_SDRAM_OR_BRAM
 config FORCE_SDRAM
 	bool
 	default y
-	depends on (AD9V3 && FORCE_SDRAM_OR_BRAM && ! ENABLE_BRAM)
-    	select ENABLE_DDR
+	depends on ((AD9V3 || BW250SOC) && FORCE_SDRAM_OR_BRAM && ! ENABLE_BRAM)
+	select ENABLE_DDR
 
 config ENABLE_DDR
 	bool
 	prompt "Enable DDR"
-	depends on (AD9V3 && ! (DISABLE_SDRAM_AND_BRAM || ENABLE_BRAM))
+	depends on ((AD9V3 || BW250SOC) && ! (DISABLE_SDRAM_AND_BRAM || ENABLE_BRAM))
 	help
 	  This option enables the on-card SDRAM.
 	  SNAP supports 8GB DDR4 on the AlphaData AD9V3 card.
@@ -297,7 +308,7 @@ config DDR3_USED
 config ENABLE_DDR4
 	bool
 	default y
-	depends on (ENABLE_DDR && (N250S || S121B || N250SP || AD8K5 || RCXVUP || FX609 || S241 || AD9V3))
+	depends on (ENABLE_DDR && (N250S || S121B || N250SP || AD8K5 || RCXVUP || FX609 || S241 || AD9V3 || BW250SOC))
 
 config DDR4_USED
 	string

--- a/software/include/osnap_global_regs.h
+++ b/software/include/osnap_global_regs.h
@@ -137,6 +137,7 @@ extern "C" {
 #define AD9V3_OC_CARD   0x031     /* OpenCAPI 3.0*/
 #define AD9H3_OC_CARD   0x032     /* OpenCAPI 3.0*/
 #define AD9H7_OC_CARD   0x033     /* OpenCAPI 3.0*/
+#define BW250SOC_OC_CARD   0x034     /* OpenCAPI 3.0*/
 
 /*
  * Freerunning Timer (FRT)

--- a/software/lib/osnap.c
+++ b/software/lib/osnap.c
@@ -133,6 +133,7 @@ struct card_2_name snap_card_2_name_tab[] = {
 	{.card_id = AD9V3_OC_CARD,  .card_name = "AD9V3"},
 	{.card_id = AD9H3_OC_CARD,  .card_name = "AD9H3"},
 	{.card_id = AD9H7_OC_CARD,  .card_name = "AD9H7"},
+        {.card_id = BW250SOC_OC_CARD,  .card_name = "BW250SOC"},
 	{.card_id = -1,             .card_name = "INVALID"}
 };
 

--- a/software/tools/oc_find_card
+++ b/software/tools/oc_find_card
@@ -31,8 +31,9 @@ normal=$(tput sgr0)
 # v2.1 : modified Feb 26th 2020 adding AD9Hx in CAPI2 and OC modes
 # v2.2 : modified March 19th 2020 adding -t (accel type) option; this is to prevent reporting 2 cards (1 CAPI2, 1 OpenCAPI) as only 1 card with 2 characteristics (both have $card ID=0)
 # v2.3 : modified April 17th 2020 adding -d (debug) option; Displays DEBUG additional info
+# v2.4 : add OC-BW250SOC card
 
-version=2.3
+version=2.4
 accel=UNKNOWN
 VERBOSE=0
 
@@ -41,7 +42,7 @@ function usage() {
 	echo "Usage: $PROGRAM"
 	echo "    [-v] Prints extra information (to be put as first param)"
 	echo "    [-d] Debug mode to display additional system info"
-	echo "    [-A] <accelerator> use either ADKU3, N250S, S121B_BPIx16, S121B_SPIx4, AD8K5, RCXVUP, FX609, S241, N250SP, AD9V3, OC-AD9V3, AD9H3, OC-AD9H3, AD9H7, OC-AD9H7, U200 or ALL"
+	echo "    [-A] <accelerator> use either ADKU3, N250S, S121B_BPIx16, S121B_SPIx4, AD8K5, RCXVUP, FX609, S241, N250SP, AD9V3, OC-AD9V3, AD9H3, OC-AD9H3, AD9H7, OC-AD9H7, OC-BW250SOC, U200 or ALL"
 	echo "    [-C] <0..3> Print accelerator name for this Card"
 	echo "    [-t] <1..3> Specifies the Type of CAPI: CAPI1.0, CAPI2.0 or OPENCAPI (CAPI3.0)"
 	echo "    [-V] provides version"
@@ -50,7 +51,7 @@ function usage() {
 	echo "  Supported CAPI Cards are:"
 	echo "     [N250S ADKU3 S121B_BPIx16 S121B_SPIx4 AD8K5 RCXVUP N250SP S241 FX609 AD9V3 AD9H3 AD9H7 U200]"
 	echo "  Supported OpenCAPI Cards are:"
-	echo "     [OC-AD9V3 OC-AD9H3 OC-AD9H7]"
+	echo "     [OC-AD9V3 OC-AD9H3 OC-AD9H7 OC-BW250SOC]"
 	echo "     ------------------- Example -----------------------------------------"
 	echo "     $PROGRAM -A ALL"
 	echo "        Print a list (e.g. 0 1 2 3) of all CAPI cards in this System"
@@ -424,7 +425,11 @@ if  [ $CardOption == 1 ]; then
 		if [ $? == 1 ]; then
         	rc=1
 		fi
-    	detect_oc_card_name $card  "0x062b" "0x0666" "OC-AD9H7"
+		detect_oc_card_name $card  "0x062b" "0x0666" "OC-AD9H7"
+        	if [ $? == 1 ]; then
+            	rc=1
+        	fi
+		detect_oc_card_name $card  "0x062b" "0x066a" "OC-BW250SOC"
         	if [ $? == 1 ]; then
             	rc=1
         	fi
@@ -570,10 +575,15 @@ case ${accel} in
 		RC=$?
 		;;
 	# OC-AD9H7 OpenCAPI 3.0 card from Alphadata
-    "OC-AD9H7")
-        detect_snap_cards "0x062b" "0x0666" "OC-AD9H7"
-        RC=$?
-        ;;
+	"OC-AD9H7")
+		detect_snap_cards "0x062b" "0x0666" "OC-AD9H7"
+		RC=$?
+		;;
+	# OC-BW250SOC OpenCAPI 3.0 card from Bittware
+	"OC-BW250SOC")
+		detect_snap_cards "0x062b" "0x066a" "OC-BW250SOC"
+		RC=$?
+		;;
 	# U200 CAPI 2.0 card from Xilinx
 	"U200")
 		detect_snap_cards "0x0632" "0x0665" "U200"
@@ -653,8 +663,11 @@ case ${accel} in
 		detect_snap_cards "0x062b" "0x0667" "OC-AD9H3"
 		RC=$((RC + $?))
 
-        detect_snap_cards "0x062b" "0x0666" "OC-AD9H7"
-        RC=$((RC + $?))
+		detect_snap_cards "0x062b" "0x0666" "OC-AD9H7"
+		RC=$((RC + $?))
+
+		detect_snap_cards "0x062b" "0x066a" "OC-BW250SOC"
+		RC=$((RC + $?))
 
 		echo -e "\nTotal $RC cards detected \n"
  		;;


### PR DESCRIPTION
* move submodule url to OpenCAPI
* switch to dev_250soc branch in submodule
* syncing submodule hardware/oc-bip to OpenCAPI/OpenCAPI3.0_Client_RefDesign branch master
* bw250soc enablement updates (#71)
* initial commit
* added complete flash file generation support
* added elf association and bin generation
Co-authored-by: Hassan Naser <hassan.naser@us.ibm.com>
* update hardware/oc-bip to dev_250soc branch of devkit
* trying to fix the oc-bip submodule link
* dispaly params
* merge with master
* add OC-BW250SOC card
* change BW250SOC ssid
* comment changed
* integrate 250-SOC oc-bip code
Signed-off-by: Bruno Mesnet <bruno.mesnet@fr.ibm.com>
* defconfigs
Signed-off-by: Alexandre CASTELLANE <alexandre.castellane@fr.ibm.com>
Co-authored-by: Lance Thompson <lancet@us.ibm.com>
Co-authored-by: Hassan Naser <hassan.naser@us.ibm.com>
Co-authored-by: Alexandre CASTELLANE <alexandre.castellane@fr.ibm.com>